### PR TITLE
Added additional snmp_packet->used verification check in the snmp_message_decode

### DIFF
--- a/os/net/app-layer/snmp/snmp-message.c
+++ b/os/net/app-layer/snmp/snmp-message.c
@@ -317,6 +317,11 @@ snmp_message_decode(snmp_packet_t *snmp_packet, snmp_header_t *header, snmp_varb
       return 0;
     }
 
+    if (snmp_packet->used == 0) {
+      LOG_DBG("Could not decode value type\n");
+      return 0;
+    }
+
     varbinds[i].value_type = *snmp_packet->in;
 
     switch(varbinds[i].value_type) {


### PR DESCRIPTION
The `snmp_message_decode` function does not properly verify the packet size when de-referencing the `in` pointer, allowing for an out-of-bounds read of 1 byte to occur in some scenarios. I originally disclosed this issue via email and was instructed to file a PR.

This PR fixes the issue by adding a check that will return if `snmp_packet->used == 0` before the de-reference, which will prevent this out of bounds read from occurring. 