### PR TITLE
Added snmp_packet->used validation check in snmp_ber_decode_string_len_buffer

### DIFF
--- a/os/net/app-layer/snmp/snmp-ber.c
+++ b/os/net/app-layer/snmp/snmp-ber.c
@@ -372,19 +372,15 @@ snmp_ber_decode_string_len_buffer(snmp_packet_t *snmp_packet, const char **str, 
     return 0;
   }
 
-  if((*snmp_packet->in & 0x80) == 0) {
+  if (snmp_packet->used == 0) {
+    return 0;
+  }
 
-    if(snmp_packet->used == 0) {
-      return 0;
-    }
+  if((*snmp_packet->in & 0x80) == 0) {
 
     *length = (uint32_t)*snmp_packet->in++;
     snmp_packet->used--;
   } else {
-
-    if(snmp_packet->used == 0) {
-      return 0;
-    }
 
     length_bytes = (uint8_t)(*snmp_packet->in++ & 0x7F);
     snmp_packet->used--;


### PR DESCRIPTION
The `snmp_ber_decode_string_len_buffer` function does not properly verify the the packet size when de-referencing the `in` pointer, allowing for an out of bounds read of 1 byte in some scenarios. I originally disclosed this issue via email and was instructed to file a PR.

This PR fixes the issue by adding a check that will return if `snmp_packet->used == 0` before the de-reference, which will prevent this out of bounds read from occurring.